### PR TITLE
html render and QTabWidget as main widget 

### DIFF
--- a/QHTMLPen.pro
+++ b/QHTMLPen.pro
@@ -1,4 +1,4 @@
-QT       += core gui
+QT       += core gui webenginewidgets
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
@@ -10,10 +10,12 @@ CONFIG += c++17
 
 SOURCES += \
     main.cpp \
-    qhtmlpen.cpp
+    qhtmlpen.cpp \
+    windowhtmlrender.cpp
 
 HEADERS += \
-    qhtmlpen.h
+    qhtmlpen.h \
+    windowhtmlrender.h
 
 FORMS += \
     qhtmlpen.ui

--- a/qhtmlpen.cpp
+++ b/qhtmlpen.cpp
@@ -6,6 +6,9 @@ QHTMLPen::QHTMLPen(QWidget *parent)
     , ui(new Ui::QHTMLPen)
 {
     ui->setupUi(this);
+
+    textEdit = new QTextEdit(this);
+    setCentralWidget(textEdit);
 }
 
 QHTMLPen::~QHTMLPen()

--- a/qhtmlpen.cpp
+++ b/qhtmlpen.cpp
@@ -8,11 +8,24 @@ QHTMLPen::QHTMLPen(QWidget *parent)
     ui->setupUi(this);
 
     textEdit = new QTextEdit(this);
+
     setCentralWidget(textEdit);
 }
 
 QHTMLPen::~QHTMLPen()
 {
     delete ui;
+}
+
+
+void QHTMLPen::Slot_render_Init()
+{
+    if(windowHTML)
+    {
+        delete windowHTML;
+    }
+    windowHTML = new WindowHtmlRender(this);
+    windowHTML -> updateRender(textEdit);
+    windowHTML -> show();
 }
 

--- a/qhtmlpen.cpp
+++ b/qhtmlpen.cpp
@@ -7,14 +7,22 @@ QHTMLPen::QHTMLPen(QWidget *parent)
 {
     ui->setupUi(this);
 
-    textEdit = new QTextEdit(this);
+    tabWidget = new QTabWidget(this);
 
-    setCentralWidget(textEdit);
+    this->addNewTab(tr("Новая вкладка"));
+
+    setCentralWidget(tabWidget);
 }
 
 QHTMLPen::~QHTMLPen()
 {
     delete ui;
+}
+
+void QHTMLPen::addNewTab(QString tabName)
+{
+    QTextEdit *textEdit = new QTextEdit(this);
+    tabWidget->addTab(textEdit, tabName);
 }
 
 
@@ -24,8 +32,19 @@ void QHTMLPen::Slot_render_Init()
     {
         delete windowHTML;
     }
+
     windowHTML = new WindowHtmlRender(this);
-    windowHTML -> updateRender(textEdit);
-    windowHTML -> show();
+    QTextEdit* currentQTextEditWidget = qobject_cast<QTextEdit*>(tabWidget->currentWidget());
+
+    if(currentQTextEditWidget)
+    {
+        windowHTML -> updateRender(currentQTextEditWidget);
+        windowHTML -> show();
+    }
+    else
+    {
+        QMessageBox::critical(nullptr, tr("Ошибка"), tr("Ошибка чтенения текущей вкладки"));
+    }
+
 }
 

--- a/qhtmlpen.h
+++ b/qhtmlpen.h
@@ -1,6 +1,7 @@
 #ifndef QHTMLPEN_H
 #define QHTMLPEN_H
 
+#include "windowhtmlrender.h"
 #include <QMainWindow>
 #include <QTextEdit>
 
@@ -16,8 +17,11 @@ public:
     QHTMLPen(QWidget *parent = nullptr);
     ~QHTMLPen();
 
+    void Slot_render_Init();
+
 private:
     Ui::QHTMLPen *ui;
     QTextEdit *textEdit;
+    WindowHtmlRender *windowHTML = nullptr;
 };
 #endif // QHTMLPEN_H

--- a/qhtmlpen.h
+++ b/qhtmlpen.h
@@ -4,6 +4,8 @@
 #include "windowhtmlrender.h"
 #include <QMainWindow>
 #include <QTextEdit>
+#include <QTabWidget>
+#include <QMessageBox>
 
 QT_BEGIN_NAMESPACE
 namespace Ui { class QHTMLPen; }
@@ -17,11 +19,14 @@ public:
     QHTMLPen(QWidget *parent = nullptr);
     ~QHTMLPen();
 
+    void addNewTab(QString);
+
     void Slot_render_Init();
 
 private:
     Ui::QHTMLPen *ui;
-    QTextEdit *textEdit;
+    QTabWidget *tabWidget;
+
     WindowHtmlRender *windowHTML = nullptr;
 };
 #endif // QHTMLPEN_H

--- a/qhtmlpen.h
+++ b/qhtmlpen.h
@@ -2,6 +2,7 @@
 #define QHTMLPEN_H
 
 #include <QMainWindow>
+#include <QTextEdit>
 
 QT_BEGIN_NAMESPACE
 namespace Ui { class QHTMLPen; }
@@ -17,5 +18,6 @@ public:
 
 private:
     Ui::QHTMLPen *ui;
+    QTextEdit *textEdit;
 };
 #endif // QHTMLPEN_H

--- a/windowhtmlrender.cpp
+++ b/windowhtmlrender.cpp
@@ -1,0 +1,21 @@
+#include "windowhtmlrender.h"
+
+WindowHtmlRender::WindowHtmlRender(QWidget *parent)
+    : QMainWindow(parent)
+{
+    setWindowTitle("html render");
+    this->resize(800, 600);
+
+    webView = new QWebEngineView(this);
+    setCentralWidget(webView);
+}
+
+WindowHtmlRender::~WindowHtmlRender()
+{
+}
+
+void WindowHtmlRender::updateRender(QTextEdit *textEdit)
+{
+    QString html = textEdit->toPlainText();
+    webView->setHtml(html);
+}

--- a/windowhtmlrender.h
+++ b/windowhtmlrender.h
@@ -1,0 +1,20 @@
+#ifndef WINDOWHTMLRENDER_H
+#define WINDOWHTMLRENDER_H
+
+#include <QWebEngineView>
+#include <QMainWindow>
+#include <QTextEdit>
+
+class WindowHtmlRender : public QMainWindow
+{
+    Q_OBJECT
+public:
+    WindowHtmlRender(QWidget *parent = nullptr);
+    ~WindowHtmlRender();
+
+    void updateRender(QTextEdit *textEdit);
+private:
+    QWebEngineView *webView;
+};
+
+#endif // WINDOWHTMLRENDER_H


### PR DESCRIPTION
The html render creates a new object each time it starts. If it is already running then it closes and opens again. The dynamic update solution was rejected because it is not convenient. Also added a method to create a new tab in QTabWidget with the addition of QTextEdit. QTextEdit objects are stored in the tabWidget object and can then be retrieved, for example by index.